### PR TITLE
Fix: Pass keyword arguments to Closure

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_application.bzl
+++ b/build_defs/internal_do_not_use/j2cl_application.bzl
@@ -10,7 +10,8 @@ def j2cl_application(
         jre_logging_log_level = "OFF",
         jre_checks_check_level = "NORMAL",
         closure_defines = dict(),
-        extra_dev_resources = []):
+        extra_dev_resources = [],
+        **kwargs):
     """Create a J2CL application target.
 
     This generates couple of convenient pre-configured targets:
@@ -61,6 +62,7 @@ def j2cl_application(
             "--rewrite_polyfills=%s" % rewrite_polyfills,
         ],
         deps = [":%s_config" % name] + deps,
+        **kwargs
     )
 
     #### Development binary setup ####
@@ -94,6 +96,7 @@ def j2cl_application(
         entry_point_defs = entry_point_defs,
         deps = deps,
         dev_resources = dev_resources,
+        **kwargs
     )
 
 def _define_js(name, defines, user_overrides):

--- a/build_defs/internal_do_not_use/j2cl_js_common.bzl
+++ b/build_defs/internal_do_not_use/j2cl_js_common.bzl
@@ -37,7 +37,8 @@ def js_devserver(
         name,
         entry_point_defs,
         deps,
-        dev_resources):
+        dev_resources,
+        **kwargs):
     """Creates a development server target."""
 
     closure_js_binary(
@@ -48,6 +49,7 @@ def js_devserver(
         # For J2CL it is in impractical to embed all source into sourcemap since
         # it bloats sourcemaps as well as it slows down bundling.
         nodefs = ["--source_map_include_content"],
+        **kwargs
     )
 
     web_library(


### PR DESCRIPTION
This changeset adds a `kwargs` entry to `js_devserver` and `j2cl_application`, to allow the invoking user to pass arbitrary arguments through to Closure (`closure_js_binary` and so on).

This fixes and closes google/j2cl#60.

Changes:
- [x] Add `kwargs` to `js_devserver`
  - [x] Pass them through to `closure_js_binary`
- [x] Add `kwargs` to `j2cl_application`
  - [x] Pass them through to `closure_js_binary`
  - [x] Pass them through to `js_devserver`